### PR TITLE
Update to handle fetching tags for images without username.

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -8,14 +8,17 @@ module Lorry
 
       # Search params: :q - search term, :n - number of results per page, :page - page number of results
       def self.search(params)
-        uri = URI("#{REGISTRY_API_URL}/search")
-        uri.query = URI.encode_www_form(params)
+        uri = URI.parse("#{REGISTRY_API_URL}/search?#{URI.encode_www_form(params)}")
 
         Net::HTTP.get_response(uri)
       end
 
       def self.list_tags(namespace, repository)
-        uri = URI("#{REGISTRY_API_URL}/repositories/#{namespace}/#{repository}/tags")
+        if namespace && repository
+          uri = URI("#{REGISTRY_API_URL}/repositories/#{namespace}/#{repository}/tags")
+        elsif repository
+          uri = URI("#{REGISTRY_API_URL}/repositories/#{repository}/tags")
+        end
 
         Net::HTTP.get_response(uri)
       end

--- a/app/routes/images.rb
+++ b/app/routes/images.rb
@@ -11,6 +11,12 @@ module Lorry
           body response.body
         end
 
+        get '/tags/:reponame' do
+          response = Lorry::Models::Registry.list_tags(nil, params[:reponame])
+          status response.code
+          body response.body
+        end
+
         get '/tags/:username/:reponame' do
           response = Lorry::Models::Registry.list_tags(params[:username], params[:reponame])
           status response.code

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Registry do
+
+  context 'search' do
+    let(:url) { 'https://index.docker.io/v1/search?q=bar' }
+    let(:uri) { URI(url) }
+
+    before do
+      allow(Net::HTTP).to receive(:get_response).with(uri)
+    end
+
+    it 'should call get response with correct uri' do
+      expect(Net::HTTP).to receive(:get_response) do |uri|
+        expect(uri.to_s).to eql(url)
+      end
+      Registry.search(q: 'bar')
+    end
+  end
+
+  context 'tags' do
+
+    context 'images with namespace and repository' do
+      let(:url) { 'https://index.docker.io/v1/repositories/foo/bar/tags' }
+      let(:uri) { URI(url) }
+
+      before do
+        allow(Net::HTTP).to receive(:get_response).with(uri)
+      end
+
+      it 'should call get response with correct uri' do
+        expect(Net::HTTP).to receive(:get_response) do |uri|
+          expect(uri.to_s).to eql(url)
+        end
+        Registry.list_tags('foo', 'bar')
+      end
+    end
+    context 'images with only repository' do
+      let(:url) { 'https://index.docker.io/v1/repositories/bar/tags' }
+      let(:uri) { URI(url) }
+
+      before do
+        allow(Net::HTTP).to receive(:get_response).with(uri)
+      end
+
+      it 'should call get response with correct uri' do
+        expect(Net::HTTP).to receive(:get_response) do |uri|
+          expect(uri.to_s).to eql(url)
+        end
+        Registry.list_tags(nil, 'bar')
+      end
+    end
+
+  end
+end

--- a/spec/routes/images_spec.rb
+++ b/spec/routes/images_spec.rb
@@ -77,19 +77,38 @@ describe Lorry::Routes::Images do
         allow(Registry).to receive(:list_tags).and_return(response)
       end
 
-      it 'calls the Registry tags api with correct params' do
-        expect(Registry).to receive(:list_tags).with('foo', 'bar').exactly(:once)
-        get '/images/tags/foo/bar'
+      context 'when image has namespace and repository' do
+        it 'calls the Registry tags api with correct params' do
+          expect(Registry).to receive(:list_tags).with('foo', 'bar').exactly(:once)
+          get '/images/tags/foo/bar'
+        end
+
+        it 'returns a success status code' do
+          get '/images/tags/foo/bar'
+          expect(last_response.status).to eql(200)
+        end
+
+        it 'returns the matching images' do
+          get '/images/tags/foo/bar'
+          expect(JSON.parse(last_response.body).count).to eql(2)
+        end
       end
 
-      it 'returns a success status code' do
-        get '/images/tags/foo/bar'
-        expect(last_response.status).to eql(200)
-      end
+      context 'when image has only repository' do
+        it 'calls the Registry tags api with correct params' do
+          expect(Registry).to receive(:list_tags).with(nil, 'bar').exactly(:once)
+          get '/images/tags/bar'
+        end
 
-      it 'returns the matching images' do
-        get '/images/tags/foo/bar'
-        expect(JSON.parse(last_response.body).count).to eql(2)
+        it 'returns a success status code' do
+          get '/images/tags/bar'
+          expect(last_response.status).to eql(200)
+        end
+
+        it 'returns the matching images' do
+          get '/images/tags/bar'
+          expect(JSON.parse(last_response.body).count).to eql(2)
+        end
       end
     end
 


### PR DESCRIPTION
In support for #91417644, finishes [#91430358]
